### PR TITLE
Fix deadlock in async processing on node.

### DIFF
--- a/crates/hotstuff-testing/src/simple_message.rs
+++ b/crates/hotstuff-testing/src/simple_message.rs
@@ -17,6 +17,7 @@ impl Test for SimpleMessage {
         let ds = TestDistributedSystem::new(n_nodes)?;
         ds.init()?;
         info!("Done initializing, ready to begin testing");
+
         Ok(())
     }
 }


### PR DESCRIPTION
Couple of fixes here. The std::sync::Mutex is throwing a warning because holding a lock from a std::sync::Mutex across an .await can lead to issues such as deadlocks in asynchronous code, especially in a runtime like Tokio. When the code awaits, it yields control back to the runtime, potentially blocking the progress of other tasks trying to acquire the lock. The recommended approach is to use an asynchronous mutex, such as tokio::sync::Mutex, which is designed to work safely with async/await.